### PR TITLE
add filter_truncated option to skip training on completions hitting response limit

### DIFF
--- a/training/verl/trainer/config/ppo_trainer.yaml
+++ b/training/verl/trainer/config/ppo_trainer.yaml
@@ -10,6 +10,7 @@ data:
   return_raw_input_ids: False  # This should be set to true when the tokenizer between policy and rm differs
   return_raw_chat: False
   n_samples: 1
+  filter_truncated: False
   filter_accuracy: False
   accuracy_lower_bound: 0.0
   accuracy_upper_bound: 1.0

--- a/training/verl/trainer/ppo/ray_trainer.py
+++ b/training/verl/trainer/ppo/ray_trainer.py
@@ -503,7 +503,7 @@ class RayPRIMETrainer(object):
                         for k, v in reward_metrics.items():
                             metrics['train_verify_score/' + k].append(v)
 
-                        if self.config.data.filter_accuracy:
+                        if self.config.data.filter_accuracy or self.config.data.filter_truncated:
                             roll_batch = self.filter(roll_batch.batch['acc'].unsqueeze(1), roll_batch, n_samples)
                     metrics['timing/verify'] += timer.last
 
@@ -617,17 +617,69 @@ class RayPRIMETrainer(object):
             logger.log(data=val_metrics, step=global_steps)
 
     def filter(self, reward_tensor, batch, n_samples):
-        reward_matrix = reward_tensor.sum(-1).reshape(-1, n_samples)
-        # reward_matrix = reward_tensor.sum(-1).reshape(n_samples, -1).T
-        acc_tensor = torch.mean(reward_matrix, dim=-1)
-        counts = Counter(acc_tensor.tolist())
-        print(" ".join(f"{k}:{v}" for k, v in sorted(counts.items())))
-        # print(acc_tensor)
-        acc_mask = (acc_tensor >= self.config.data.accuracy_lower_bound) & (
-                    acc_tensor <= self.config.data.accuracy_upper_bound)
-        acc_mask = acc_mask.repeat_interleave(n_samples)
-        batch = batch.slice(acc_mask)
-        return batch
+        """
+        Filter responses based on accuracy and truncation criteria.
+        
+        Args:
+            reward_tensor: Tensor containing accuracy scores
+            batch: DataProto batch containing responses
+            n_samples: Number of responses per prompt
+        
+        Returns:
+            DataProto: Filtered batch
+        """
+        # First do accuracy filtering if enabled
+        if self.config.data.filter_accuracy:
+            reward_matrix = reward_tensor.sum(-1).reshape(-1, n_samples)
+            acc_tensor = torch.mean(reward_matrix, dim=-1)
+            counts = Counter(acc_tensor.tolist())
+            print("Accuracy distribution:", " ".join(f"{k}:{v}" for k, v in sorted(counts.items())))
+            
+            acc_mask = (acc_tensor >= self.config.data.accuracy_lower_bound) & (
+                        acc_tensor <= self.config.data.accuracy_upper_bound)
+        else:
+            # If accuracy filtering disabled, keep all samples
+            acc_mask = torch.ones(len(batch) // n_samples, dtype=torch.bool, device=reward_tensor.device)
+        
+        # Then do truncation filtering if enabled
+        if self.config.data.filter_truncated:
+            responses = batch.batch['responses']
+            attention_mask = batch.batch['attention_mask']
+            response_mask = attention_mask[:, -responses.size(1):]
+            
+            # Calculate response lengths
+            response_lengths = response_mask.sum(-1)  # (batch_size,)
+            response_lengths = response_lengths.reshape(-1, n_samples)  # (num_prompts, n_samples)
+            
+            # Get max possible length from config
+            max_len = self.config.data.max_response_length
+            
+            # Check if any response in the group hits max length (indicating possible truncation)
+            has_truncated = (response_lengths >= max_len).any(dim=-1)
+            
+            # Print distribution of truncated vs non-truncated
+            truncated_counts = Counter(has_truncated.tolist())
+            print("Truncation distribution:", 
+                f"Truncated: {truncated_counts[True] if True in truncated_counts else 0}, "
+                f"Non-truncated: {truncated_counts[False] if False in truncated_counts else 0}")
+            
+            # Keep only prompts where no response was truncated
+            trunc_mask = ~has_truncated
+        else:
+            # If truncation filtering disabled, keep all samples
+            trunc_mask = torch.ones(len(batch) // n_samples, dtype=torch.bool, device=reward_tensor.device)
+        
+        # Combine both masks
+        combined_mask = acc_mask & trunc_mask
+        
+        # Expand mask to cover all samples for each prompt
+        final_mask = combined_mask.repeat_interleave(n_samples)
+        
+        # Apply the mask to the batch
+        filtered_batch = batch.slice(final_mask)
+        
+        print(f"Filtered batch size: {len(filtered_batch)} (from original size: {len(batch)})")
+        return filtered_batch
 
     def add_to_buffer(self, batch, batch_size, n_samples):
         buffer_length = len(batch) // n_samples - batch_size


### PR DESCRIPTION
idea: avoid training on completions that hit `max_response_length`, since it's possible they would reach correct answer / contain high quality reasoning but get unfairly penalized since answer is truncated

(eval wip)