### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/eval/Coding/livecodebench/LiveCodeBench-main/lcb_runner/runner/main.py
+++ b/eval/Coding/livecodebench/LiveCodeBench-main/lcb_runner/runner/main.py
@@ -19,10 +19,16 @@ from lcb_runner.runner.scenario_router import (
 def main():
     args = get_args()
     if args.model not in LanguageModelStore:
+        model_style = LMStyle.Qwen25Math
+        if os.getenv("FORGE_API_KEY") and "/" in args.model:
+            model_style = LMStyle.OpenAIChat
+            model_suffix = args.model.split("/", 1)[1].lower()
+            if model_suffix.startswith("o1-"):
+                model_style = LMStyle.OpenAIReason
         model = LanguageModel(
                 str(args.model),
                 str(args.model),
-                LMStyle.Qwen25Math,
+                model_style,
                 datetime(2023, 1, 1),
                 link="https://huggingface.co/Qwen/Qwen2.5-Math-7B-Instruct",
             )

--- a/eval/Coding/livecodebench/LiveCodeBench-main/lcb_runner/runner/oai_runner.py
+++ b/eval/Coding/livecodebench/LiveCodeBench-main/lcb_runner/runner/oai_runner.py
@@ -12,9 +12,15 @@ from lcb_runner.runner.base_runner import BaseRunner
 
 
 class OpenAIRunner(BaseRunner):
-    client = OpenAI(
-        api_key=os.getenv("OPENAI_KEY"),
-    )
+    if os.getenv("FORGE_API_KEY"):
+        client = OpenAI(
+            api_key=os.getenv("FORGE_API_KEY"),
+            base_url=os.getenv("FORGE_API_BASE") or "https://api.forge.tensorblock.co/v1",
+        )
+    else:
+        client = OpenAI(
+            api_key=os.getenv("OPENAI_KEY"),
+        )
 
     def __init__(self, args, model):
         super().__init__(args, model)


### PR DESCRIPTION
## Summary
Adds Forge API support to LiveCodeBench's OpenAI runner. When `FORGE_API_KEY` is set, the runner routes requests through Forge's OpenAI-compatible API, with automatic model style detection for chat and reasoning models.

## Changes
- `lcb_runner/runner/main.py`: Auto-detect `OpenAIChat`/`OpenAIReason` model style for Forge models (identified by `Provider/model-name` format)
- `lcb_runner/runner/oai_runner.py`: Conditionally initialize `OpenAI` client with Forge API credentials when `FORGE_API_KEY` is set

## Usage
```bash
# Set environment variables
export FORGE_API_KEY="your-forge-api-key"

# Run with a Forge model (Provider/model-name format)
python -m lcb_runner.runner.main --model "OpenAI/gpt-4o-mini" ...
```

## Test Evidence
All existing tests pass. The change is additive — when `FORGE_API_KEY` is not set, behavior is identical to upstream.

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/forge) is an open-source middleware service for unified AI model provider management. It routes requests across 40+ AI providers with access to thousands of models through a single OpenAI-compatible API.

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview